### PR TITLE
Proposed change to arguments of signed function.

### DIFF
--- a/src/costas_loop.vhd
+++ b/src/costas_loop.vhd
@@ -210,8 +210,8 @@ BEGIN
 ------------------------------------------------------------------------------------------------------
 -- Low Pass Filter
 
-	rx_sin_filt_sum <= resize(rx_sin_filt_acc + shift_right(signed(rx_sin) - rx_sin_filt_acc, to_integer(signed(lpf_alpha))), ACC_W);
-	rx_cos_filt_sum <= resize(rx_cos_filt_acc + shift_right(signed(rx_cos) - rx_cos_filt_acc, to_integer(signed(lpf_alpha))), ACC_W);
+	rx_sin_filt_sum <= resize(rx_sin_filt_acc + shift_right(signed(rx_sin - rx_sin_filt_acc), to_integer(signed(lpf_alpha))), ACC_W);
+	rx_cos_filt_sum <= resize(rx_cos_filt_acc + shift_right(signed(rx_cos - rx_cos_filt_acc), to_integer(signed(lpf_alpha))), ACC_W);
 
 	rx_sin_filt_sat <= to_signed(MAX_ACC_POS, ACC_W) WHEN rx_sin_filt_sum(ACC_W -1) = '0' AND rx_sin_filt_sum(ACC_W -2) = '1' ELSE
 					   to_signed(MAX_ACC_NEG, ACC_W) WHEN rx_sin_filt_sum(ACC_W -1) = '1' AND rx_sin_filt_sum(ACC_W -2) = '0' ELSE

--- a/src/costas_loop.vhd
+++ b/src/costas_loop.vhd
@@ -210,8 +210,9 @@ BEGIN
 ------------------------------------------------------------------------------------------------------
 -- Low Pass Filter
 
-	rx_sin_filt_sum <= resize(rx_sin_filt_acc + shift_right(signed(rx_sin - rx_sin_filt_acc), to_integer(signed(lpf_alpha))), ACC_W);
-	rx_cos_filt_sum <= resize(rx_cos_filt_acc + shift_right(signed(rx_cos - rx_cos_filt_acc), to_integer(signed(lpf_alpha))), ACC_W);
+	rx_sin_filt_sum <= resize(rx_sin_filt_acc + shift_right((rx_sin - rx_sin_filt_acc), to_integer(signed(lpf_alpha))), ACC_W);
+	rx_cos_filt_sum <= resize(rx_cos_filt_acc + shift_right((rx_cos - rx_cos_filt_acc), to_integer(signed(lpf_alpha))), ACC_W);
+
 
 	rx_sin_filt_sat <= to_signed(MAX_ACC_POS, ACC_W) WHEN rx_sin_filt_sum(ACC_W -1) = '0' AND rx_sin_filt_sum(ACC_W -2) = '1' ELSE
 					   to_signed(MAX_ACC_NEG, ACC_W) WHEN rx_sin_filt_sum(ACC_W -1) = '1' AND rx_sin_filt_sum(ACC_W -2) = '0' ELSE


### PR DESCRIPTION
For these two lines in the Low Pass Filter section of the Costas Loop, 

```
rx_sin_filt_sum <= resize(rx_sin_filt_acc + shift_right(signed(rx_sin) - rx_sin_filt_acc, to_integer(signed(lpf_alpha))), ACC_W);
rx_cos_filt_sum <= resize(rx_cos_filt_acc + shift_right(signed(rx_cos) - rx_cos_filt_acc, to_integer(signed(lpf_alpha))), ACC_W);

```
Should the signed function include rx_sin_filt_acc and rx_cos_filt_acc? Low risk, but it seems like it might have been intended to be written that way instead of just having rx_sin and rx_cos included in the signed function?

```
rx_sin_filt_sum <= resize(rx_sin_filt_acc + shift_right(signed(rx_sin - rx_sin_filt_acc), to_integer(signed(lpf_alpha))), ACC_W);
rx_cos_filt_sum <= resize(rx_cos_filt_acc + shift_right(signed(rx_cos - rx_cos_filt_acc), to_integer(signed(lpf_alpha))), ACC_W);
```